### PR TITLE
Update Aqua to workaround ambiguity detection in Julia 1.6.0-DEV.816

### DIFF
--- a/test/environments/jl10/Manifest.toml
+++ b/test/environments/jl10/Manifest.toml
@@ -6,7 +6,7 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "4f6f7b3008a7474dac7696889e93663d652cef6f"
+git-tree-sha1 = "0ce3be2271a966746ea05caf493edf45162cce1b"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/environments/jl10/Manifest.toml
+++ b/test/environments/jl10/Manifest.toml
@@ -6,11 +6,11 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "2c366fa12569d9232b5b7cfa37c36f3f1b2665b2"
+git-tree-sha1 = "4f6f7b3008a7474dac7696889e93663d652cef6f"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.4-DEV"
+version = "0.4.5-DEV"
 
 [[BangBang]]
 deps = ["Compat", "ConstructionBase", "Future", "InitialValues", "LinearAlgebra", "Requires", "Setfield", "Tables", "ZygoteRules"]

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -8,11 +8,11 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "2c366fa12569d9232b5b7cfa37c36f3f1b2665b2"
+git-tree-sha1 = "4f6f7b3008a7474dac7696889e93663d652cef6f"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.4-DEV"
+version = "0.4.5-DEV"
 
 [[BangBang]]
 deps = ["Compat", "ConstructionBase", "Future", "InitialValues", "LinearAlgebra", "Requires", "Setfield", "Tables", "ZygoteRules"]

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -8,7 +8,7 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "4f6f7b3008a7474dac7696889e93663d652cef6f"
+git-tree-sha1 = "0ce3be2271a966746ea05caf493edf45162cce1b"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/environments/old/Manifest.toml
+++ b/test/environments/old/Manifest.toml
@@ -6,7 +6,7 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "4f6f7b3008a7474dac7696889e93663d652cef6f"
+git-tree-sha1 = "0ce3be2271a966746ea05caf493edf45162cce1b"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/environments/old/Manifest.toml
+++ b/test/environments/old/Manifest.toml
@@ -6,11 +6,11 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "2c366fa12569d9232b5b7cfa37c36f3f1b2665b2"
+git-tree-sha1 = "4f6f7b3008a7474dac7696889e93663d652cef6f"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.4-DEV"
+version = "0.4.5-DEV"
 
 [[BangBang]]
 deps = ["Compat", "ConstructionBase", "Future", "InitialValues", "LinearAlgebra", "Requires", "Setfield", "Tables", "ZygoteRules"]


### PR DESCRIPTION
## Commit Message
Update Aqua to workaround ambiguity detection in Julia 1.6.0-DEV.816 (#197)

See also: https://github.com/JuliaTesting/Aqua.jl/pull/32