### PR TITLE
Update to Aqua 0.5

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -19,6 +19,6 @@ TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-Aqua = "0.4.7"
+Aqua = "0.5"
 DataFrames = ">= 0.20"
 StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12.1"

--- a/test/environments/jl10/Manifest.toml
+++ b/test/environments/jl10/Manifest.toml
@@ -6,11 +6,11 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "ef5f638a83ec0099904ac1fe2cc254286e801a54"
+git-tree-sha1 = "41c0492682754f55c2564577c92bafb8968090e3"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.7"
+version = "0.5.0-DEV"
 
 [[BangBang]]
 deps = ["Compat", "ConstructionBase", "Future", "InitialValues", "LinearAlgebra", "Requires", "Setfield", "Tables", "ZygoteRules"]

--- a/test/environments/jl10/Manifest.toml
+++ b/test/environments/jl10/Manifest.toml
@@ -6,7 +6,7 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "41c0492682754f55c2564577c92bafb8968090e3"
+git-tree-sha1 = "71bbfd1312212c06ebf8e97b9f3513603d42e001"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/environments/jl10/Manifest.toml
+++ b/test/environments/jl10/Manifest.toml
@@ -12,9 +12,9 @@ version = "2.0.2"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "6775799bef0635cb3d96d2fdd0f145087edf8a73"
+git-tree-sha1 = "b28b1f08e814090ef35eec6ab974264b3a93c862"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.9"
+version = "0.5.0"
 
 [[ArrayLayouts]]
 deps = ["FillArrays", "LinearAlgebra"]

--- a/test/environments/jl10/Project.toml
+++ b/test/environments/jl10/Project.toml
@@ -19,6 +19,6 @@ TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-Aqua = "0.4.7"
+Aqua = "0.5"
 DataFrames = ">= 0.20"
 StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12.1"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -8,7 +8,7 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "41c0492682754f55c2564577c92bafb8968090e3"
+git-tree-sha1 = "71bbfd1312212c06ebf8e97b9f3513603d42e001"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -8,11 +8,11 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "ef5f638a83ec0099904ac1fe2cc254286e801a54"
+git-tree-sha1 = "41c0492682754f55c2564577c92bafb8968090e3"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.7"
+version = "0.5.0-DEV"
 
 [[BangBang]]
 deps = ["Compat", "ConstructionBase", "Future", "InitialValues", "LinearAlgebra", "Requires", "Setfield", "Tables", "ZygoteRules"]

--- a/test/environments/main/Manifest.toml
+++ b/test/environments/main/Manifest.toml
@@ -14,9 +14,9 @@ version = "2.0.2"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "6775799bef0635cb3d96d2fdd0f145087edf8a73"
+git-tree-sha1 = "b28b1f08e814090ef35eec6ab974264b3a93c862"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.9"
+version = "0.5.0"
 
 [[ArrayLayouts]]
 deps = ["FillArrays", "LinearAlgebra", "SparseArrays"]

--- a/test/environments/main/Project.toml
+++ b/test/environments/main/Project.toml
@@ -19,6 +19,6 @@ TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-Aqua = "0.4.7"
+Aqua = "0.5"
 DataFrames = ">= 0.20"
 StaticArrays = "0.8, 0.9, 0.10, 0.11, 0.12.1"

--- a/test/environments/old/Manifest.toml
+++ b/test/environments/old/Manifest.toml
@@ -6,11 +6,11 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "ef5f638a83ec0099904ac1fe2cc254286e801a54"
+git-tree-sha1 = "41c0492682754f55c2564577c92bafb8968090e3"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.7"
+version = "0.5.0-DEV"
 
 [[BangBang]]
 deps = ["Compat", "ConstructionBase", "Future", "InitialValues", "LinearAlgebra", "Requires", "Setfield", "Tables", "ZygoteRules"]

--- a/test/environments/old/Manifest.toml
+++ b/test/environments/old/Manifest.toml
@@ -6,9 +6,9 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "6775799bef0635cb3d96d2fdd0f145087edf8a73"
+git-tree-sha1 = "b28b1f08e814090ef35eec6ab974264b3a93c862"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"
-version = "0.4.9"
+version = "0.5.0"
 
 [[BangBang]]
 deps = ["Compat", "ConstructionBase", "Future", "InitialValues", "LinearAlgebra", "Requires", "Setfield", "Tables", "ZygoteRules"]

--- a/test/environments/old/Manifest.toml
+++ b/test/environments/old/Manifest.toml
@@ -6,7 +6,7 @@ version = "0.5.0"
 
 [[Aqua]]
 deps = ["Pkg", "Test"]
-git-tree-sha1 = "41c0492682754f55c2564577c92bafb8968090e3"
+git-tree-sha1 = "71bbfd1312212c06ebf8e97b9f3513603d42e001"
 repo-rev = "master"
 repo-url = "https://github.com/tkf/Aqua.jl.git"
 uuid = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/environments/old/Project.toml
+++ b/test/environments/old/Project.toml
@@ -23,7 +23,7 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 ZygoteRules = "700de1a5-db45-46bc-99cf-38207098b444"
 
 [compat]
-Aqua = "0.4.7"
+Aqua = "0.5"
 Compat = "= 2.0"
 ConstructionBase = "= 0.1"
 InitialValues = "= 0.2.5"

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -8,10 +8,6 @@ using Test
 Aqua.test_all(
     BangBang;
     ambiguities=(exclude=[Base.get, Setfield.set, Setfield.modify],),
-    project_extras = true,
-    stale_deps = true,
-    deps_compat = true,
-    project_toml_formatting = true,
 )
 
 @testset "Compare test/Project.toml and test/environments/main/Project.toml" begin


### PR DESCRIPTION
- [x] Release https://github.com/JuliaTesting/Aqua.jl/pull/36

## Commit Message
Update to Aqua 0.5 (#200)

It simplifies `test_aqua.jl`.