### PR TITLE
Improve inferrability of `setproperty!!`

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -568,7 +568,8 @@ end
 An alias of `setproperties!!(value, (name=x,))`.
 """
 setproperty!!
-setproperty!!(value, name::Symbol, x) = setproperties!!(value, (; name => x))
+@inline setproperty!!(value, name::Symbol, x) =
+    setproperties!!(value, NamedTuple{(name,)}((x,)))
 
 """
     materialize!!(dest, x)

--- a/test/test_setproperty.jl
+++ b/test/test_setproperty.jl
@@ -21,4 +21,10 @@ end
     @test ms.b == 2
 end
 
+@testset "inference" begin
+    nt = (a = 1, b = 2)
+    f!!(nt) = setproperty!!(nt, :a, 3)
+    @test @inferred(f!!(nt)) == (a = 3, b = 2)
+end
+
 end  # module


### PR DESCRIPTION
Let's help the inference until `name` is lifted to the type domain.
Adding `@inline` to the old implementation was enough.  But it's better
to use the constructor directly to relying another constprop.

close #226